### PR TITLE
Add Release workflows, and update CI to delete previous artifacts

### DIFF
--- a/.github/workflows/ci-2g.yml
+++ b/.github/workflows/ci-2g.yml
@@ -53,7 +53,7 @@ jobs:
             })
 
             res.data.artifacts
-              .filter(({ name }) => name === "${JETSON_NANO_BOARD}")
+              .filter(({ name }) => name === process.env.JETSON_NANO_BOARD)
               .forEach(({ id }) => {
                 github.rest.actions.deleteArtifact({
                   owner: context.repo.owner,

--- a/.github/workflows/ci-2g.yml
+++ b/.github/workflows/ci-2g.yml
@@ -42,9 +42,29 @@ jobs:
         run: |
           tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
       
+      - name: Delete previous artifact
+        uses: actions/github-script@v6
+        id: artifact
+        with:
+          script: |
+            const res = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+
+            res.data.artifacts
+              .filter(({ name }) => name === "${JETSON_NANO_BOARD}")
+              .forEach(({ id }) => {
+                github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: id,
+                })
+              })
+
       - name: Upload image
         uses: actions/upload-artifact@v2
         with:
-          name: ${JETSON_NANO_BOARD}.tar.gz
+          name: ${{ env.JETSON_NANO_BOARD }}
           path: |
-            ${JETSON_NANO_BOARD}.tar.gz
+            ${{ env.JETSON_NANO_BOARD }}.tar.gz

--- a/.github/workflows/ci-2g.yml
+++ b/.github/workflows/ci-2g.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - feature-*
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      JETSON_ROOTFS_DIR: /tmp/jetson-builder/rootfs
+      JETSON_BUILD_DIR: /tmp/jetson-builder/build
+      JETSON_NANO_BOARD: jetson-nano
+      JETSON_NANO_REVISION: 300
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build docker image
+        run: docker buildx build --platform linux/arm64 -t jetson-nano-image .
+
+      - name: Export rootfs
+        run: |
+          docker export $(docker create --name nano-rootfs --platform linux/arm64 jetson-nano-image) -o rootfs.tar
+          docker rm nano-rootfs
+          mkdir -p /tmp/jetson-builder/rootfs
+          sudo tar --same-owner -xf rootfs.tar -C /tmp/jetson-builder/rootfs
+
+      - name: Create jetson.img
+        run: |
+          sudo apt install -y libxml2-utils
+          sudo -E ./create-image.sh
+
+      - name: Make tarball
+        run: |
+          tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
+      
+      - name: Upload image
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${JETSON_NANO_BOARD}.tar.gz
+          path: |
+            ${JETSON_NANO_BOARD}.tar.gz

--- a/.github/workflows/ci-2g.yml
+++ b/.github/workflows/ci-2g.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
       
-      - name: Delete previous artifact
+      - name: Delete previous CI artifact
         uses: actions/github-script@v6
         id: artifact
         with:

--- a/.github/workflows/ci-4g.yml
+++ b/.github/workflows/ci-4g.yml
@@ -51,9 +51,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
             })
-
             res.data.artifacts
-              .filter(({ name }) => name === "${JETSON_NANO_BOARD}")
+              .filter(({ name }) => name === process.env.JETSON_NANO_BOARD)
               .forEach(({ id }) => {
                 github.rest.actions.deleteArtifact({
                   owner: context.repo.owner,

--- a/.github/workflows/ci-4g.yml
+++ b/.github/workflows/ci-4g.yml
@@ -42,9 +42,29 @@ jobs:
         run: |
           tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
       
+      - name: Delete previous artifact
+        uses: actions/github-script@v6
+        id: artifact
+        with:
+          script: |
+            const res = await github.rest.actions.listArtifactsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+
+            res.data.artifacts
+              .filter(({ name }) => name === "${JETSON_NANO_BOARD}")
+              .forEach(({ id }) => {
+                github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: id,
+                })
+              })
+        
       - name: Upload image
         uses: actions/upload-artifact@v2
         with:
-          name: ${JETSON_NANO_BOARD}.tar.gz
+          name: ${{ env.JETSON_NANO_BOARD }}
           path: |
-            ${JETSON_NANO_BOARD}.tar.gz
+            ${{ env.JETSON_NANO_BOARD }}.tar.gz

--- a/.github/workflows/ci-4g.yml
+++ b/.github/workflows/ci-4g.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - feature-*
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      JETSON_ROOTFS_DIR: /tmp/jetson-builder/rootfs
+      JETSON_BUILD_DIR: /tmp/jetson-builder/build
+      JETSON_NANO_BOARD: jetson-nano-2gb
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build docker image
+        run: docker buildx build --platform linux/arm64 -t jetson-nano-image .
+
+      - name: Export rootfs
+        run: |
+          docker export $(docker create --name nano-rootfs --platform linux/arm64 jetson-nano-image) -o rootfs.tar
+          docker rm nano-rootfs
+          mkdir -p /tmp/jetson-builder/rootfs
+          sudo tar --same-owner -xf rootfs.tar -C /tmp/jetson-builder/rootfs
+
+      - name: Create jetson.img
+        run: |
+          sudo apt install -y libxml2-utils
+          sudo -E ./create-image.sh
+
+      - name: Make tarball
+        run: |
+          tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
+      
+      - name: Upload image
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${JETSON_NANO_BOARD}.tar.gz
+          path: |
+            ${JETSON_NANO_BOARD}.tar.gz

--- a/.github/workflows/ci-4g.yml
+++ b/.github/workflows/ci-4g.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
       
-      - name: Delete previous artifact
+      - name: Delete previous CI artifact
         uses: actions/github-script@v6
         id: artifact
         with:

--- a/.github/workflows/release-2g.yml
+++ b/.github/workflows/release-2g.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  release:
+    branches: [main, master]
+    types: [edited, published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    env:
+      JETSON_ROOTFS_DIR: /tmp/jetson-builder/rootfs
+      JETSON_BUILD_DIR: /tmp/jetson-builder/build
+      JETSON_NANO_BOARD: jetson-nano-2gb
+
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build docker image
+        run: docker buildx build --platform linux/arm64 -t jetson-nano-image .
+
+      - name: Export rootfs
+        run: |
+          docker export $(docker create --name nano-rootfs --platform linux/arm64 jetson-nano-image) -o rootfs.tar
+          docker rm nano-rootfs
+          mkdir -p /tmp/jetson-builder/rootfs
+          sudo tar --same-owner -xf rootfs.tar -C /tmp/jetson-builder/rootfs
+
+      - name: Create jetson disk image
+        run: |
+          sudo apt install -y libxml2-utils
+          sudo -E ./create-image.sh
+
+      - name: Make tarball
+        run: |
+          tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
+
+      - name: Publish binaries  
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${JETSON_NANO_BOARD}.tar.gz

--- a/.github/workflows/release-4g.yml
+++ b/.github/workflows/release-4g.yml
@@ -1,26 +1,20 @@
-name: CI
+name: Release
 
 on:
-  push:
+  release:
     branches: [main, master]
-  pull_request:
+    types: [edited, published]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - board: jetson-nano
-            revision: 300
 
     env:
       JETSON_ROOTFS_DIR: /tmp/jetson-builder/rootfs
       JETSON_BUILD_DIR: /tmp/jetson-builder/build
-      JETSON_NANO_BOARD: ${{ matrix.board }}
-      JETSON_NANO_REVISION: ${{ matrix.revision }}
+      JETSON_NANO_BOARD: jetson-nano
+      JETSON_NANO_REVISION: 300
+
     steps:
       - uses: actions/checkout@v2
 
@@ -37,14 +31,18 @@ jobs:
           mkdir -p /tmp/jetson-builder/rootfs
           sudo tar --same-owner -xf rootfs.tar -C /tmp/jetson-builder/rootfs
 
-      - name: Create jetson.img
+      - name: Create jetson disk image
         run: |
           sudo apt install -y libxml2-utils
           sudo -E ./create-image.sh
 
-      - name: Upload image
-        uses: actions/upload-artifact@v2
+      - name: Make tarball
+        run: |
+          tar -czvf ${JETSON_NANO_BOARD}.tar.gz ${JETSON_NANO_BOARD}.img
+
+      - name: Publish binaries  
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ matrix.board }}-r${{ matrix.revision }}
-          path: |
-            jetson.img
+          args: ${JETSON_NANO_BOARD}.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,22 @@ FROM ubuntu:20.04 as base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update
-RUN apt install -y ca-certificates
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 
-RUN apt install -y sudo
-RUN apt install -y ssh
-RUN apt install -y netplan.io
+RUN apt-get install -y sudo
+RUN apt-get install -y ssh
+RUN apt-get install -y netplan.io
 
 # resizerootfs
-RUN apt install -y udev
-RUN apt install -y parted
+RUN apt-get install -y udev
+RUN apt-get install -y parted
 
 # ifconfig
-RUN apt install -y net-tools
+RUN apt-get install -y net-tools
 
 # needed by knod-static-nodes to create a list of static device nodes
-RUN apt install -y kmod
+RUN apt-get install -y kmod
 
 # Install our resizerootfs service
 COPY root/etc/systemd/ /etc/systemd
@@ -32,13 +32,13 @@ RUN touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
 
 COPY root/etc/apt/ /etc/apt
 COPY root/usr/share/keyrings /usr/share/keyrings
-RUN apt update
+RUN apt-get update
 
 # nv-l4t-usb-device-mode
-RUN apt install -y bridge-utils
+RUN apt-get install -y bridge-utils
 
 # https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/updating_jetson_and_host.html
-RUN apt install -y -o Dpkg::Options::="--force-overwrite" \
+RUN apt-get install -y -o Dpkg::Options::="--force-overwrite" \
     nvidia-l4t-core \
     nvidia-l4t-init \
     nvidia-l4t-bootloader \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04 as base
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt update
 RUN apt install -y ca-certificates
 

--- a/create-image.sh
+++ b/create-image.sh
@@ -64,7 +64,7 @@ case "$JETSON_NANO_BOARD" in
     jetson-nano-2gb)
         printf "Create image for Jetson nano 2GB board... "
         ROOTFS_DIR=$JETSON_ROOTFS_DIR $JETSON_BUILD_DIR/Linux_for_Tegra/tools/jetson-disk-image-creator.sh \
-            -o jetson.img -b jetson-nano-2gb-devkit
+            -o $JETSON_NANO_BOARD.img -b jetson-nano-2gb-devkit
         printf "[OK]\n"
         ;;
 
@@ -83,4 +83,4 @@ case "$JETSON_NANO_BOARD" in
 esac
 
 printf "\e[32mImage created successfully\n"
-printf "Image location ./jetson.img\n"
+printf "Image location ./$JETSON_NANO_BOARD.img\n"

--- a/create-image.sh
+++ b/create-image.sh
@@ -72,7 +72,7 @@ case "$JETSON_NANO_BOARD" in
         nano_board_revision=${JETSON_NANO_REVISION:=300}
         printf "Creating image for Jetson nano board (%s revision)... " $nano_board_revision
         ROOTFS_DIR=$JETSON_ROOTFS_DIR $JETSON_BUILD_DIR/Linux_for_Tegra/tools/jetson-disk-image-creator.sh \
-            -o jetson.img -b jetson-nano -r $nano_board_revision
+            -o $JETSON_NANO_BOARD.img -b jetson-nano -r $nano_board_revision
         printf "[OK]\n"
         ;;
 


### PR DESCRIPTION
This PR adds the following functionality

- Add Release workflows that create artifacts on release
- Build 2GB and 4GB images for release and CI workflows
- Ensure that CI workflows delete previously built artifacts if current run succeeds